### PR TITLE
Autoyaw loiter

### DIFF
--- a/ArduCopter/mode.cpp
+++ b/ArduCopter/mode.cpp
@@ -892,3 +892,20 @@ void Mode::input_euler_angle_roll_pitch_proximity_yaw(float euler_roll_angle_cd,
 #endif
     attitude_control->input_euler_angle_roll_pitch_euler_rate_yaw(euler_roll_angle_cd, euler_pitch_angle_cd, euler_yaw_rate_cds);
 }
+
+void Mode::input_thrust_vector_proximity_yaw(Vector3f thrust_vec, float euler_yaw_rate_cds)
+{
+#if HAL_PROXIMITY_ENABLED == ENABLED
+    // Proximity based automatic yawing if no pilot input
+    if (is_zero(euler_yaw_rate_cds) && copter.auto_yaw_enabled && is_positive(copter.g2.auto_yaw_min_dist)) {
+        float angle, distance;
+        if (copter.g2.proximity.get_closest_object(angle, distance)) {
+            if (distance < copter.g2.auto_yaw_min_dist) {
+                attitude_control->input_thrust_vector_heading(thrust_vec, degrees(wrap_PI(copter.ahrs.get_yaw() + radians(angle))) * 100);
+                return;
+            }
+        }
+    }
+#endif
+    attitude_control->input_thrust_vector_rate_heading(thrust_vec, euler_yaw_rate_cds);
+}

--- a/ArduCopter/mode.h
+++ b/ArduCopter/mode.h
@@ -105,6 +105,7 @@ public:
     virtual bool use_pilot_yaw() const {return true; }
     // apply proximity auto yaw to input_euler_angle_roll_pitch_euler_rate_yaw
     void input_euler_angle_roll_pitch_proximity_yaw(float euler_roll_angle_cd, float euler_pitch_angle_cd, float euler_yaw_rate_cds);
+    void input_thrust_vector_proximity_yaw(Vector3f thrust_vec, float euler_yaw_rate_cds);
 
 protected:
 

--- a/ArduCopter/mode_althold.cpp
+++ b/ArduCopter/mode_althold.cpp
@@ -85,7 +85,7 @@ void ModeAltHold::run()
 #endif
 
         // get avoidance adjusted climb rate
-        // target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
 
         // update the vertical offset based on the surface measurement
         copter.surface_tracking.update_surface_offset();

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -172,7 +172,7 @@ void ModeLoiter::run()
         input_thrust_vector_proximity_yaw(loiter_nav->get_thrust_vector(), target_yaw_rate);
 
         // get avoidance adjusted climb rate
-        // target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
+        target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);
 
         // update the vertical offset based on the surface measurement
         copter.surface_tracking.update_surface_offset();

--- a/ArduCopter/mode_loiter.cpp
+++ b/ArduCopter/mode_loiter.cpp
@@ -169,7 +169,7 @@ void ModeLoiter::run()
         loiter_nav->update();
 
         // call attitude controller
-        attitude_control->input_thrust_vector_rate_heading(loiter_nav->get_thrust_vector(), target_yaw_rate);
+        input_thrust_vector_proximity_yaw(loiter_nav->get_thrust_vector(), target_yaw_rate);
 
         // get avoidance adjusted climb rate
         // target_climb_rate = get_avoidance_adjusted_climbrate(target_climb_rate);

--- a/libraries/AC_Avoidance/AC_Avoid.cpp
+++ b/libraries/AC_Avoidance/AC_Avoid.cpp
@@ -104,7 +104,7 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("BACKUP_DZ", 9, AC_Avoid, _backup_deadzone, 0.10f),
 
-    // @Param: MARGIN_ROOF
+    // @Param: MARGIN_RF
     // @DisplayName: Avoidance distance for roof
     // @Description: Vehicle will attempt to stay at least this distance (in meters) from surfaces directly in front of lidar set as TOP
     // @Units: m
@@ -112,8 +112,8 @@ const AP_Param::GroupInfo AC_Avoid::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("MARGIN_RF", 10, AC_Avoid, _margin_roof, 2.0f),
 
-    // @Param: MARGIN_ADVANCE
-    // @DisplayName: Distance at wich avoid will work
+    // @Param: ADVANCE
+    // @DisplayName: Distance at which avoid will work
     // @Description: Vehicle wont try to mantain a distance from the wall unless its at a distance smaller than this one
     // @Units: m
     // @Range: 1 10
@@ -407,8 +407,8 @@ void AC_Avoid::adjust_velocity_z(float kP, float accel_cmss, float& climb_rate_c
     // get distance from proximity sensor
     float proximity_alt_diff;
     AP_Proximity *proximity = AP::proximity();
-    if (proximity && proximity_avoidance_enabled() && proximity->get_upward_distance(proximity_alt_diff)) {
-        proximity_alt_diff -= _margin;
+    if (is_positive(_margin_roof) && proximity && proximity_avoidance_enabled() && proximity->get_upward_distance(proximity_alt_diff)) {
+        proximity_alt_diff -= _margin_roof;
         if (!limit_alt || proximity_alt_diff < alt_diff) {
             alt_diff = proximity_alt_diff;
             limit_alt = true;

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -353,8 +353,6 @@ bool RangeFinder::_add_backend(AP_RangeFinder_Backend *backend, uint8_t instance
             gcs().send_text(MAV_SEVERITY_INFO, "Initialized unknown orientation lidar");
             break;
     }
-
-    drivers[num_instances++] = backend;
     return true;
 }
 


### PR DESCRIPTION
This fixes a rangefinder allocation bug picked up in the re-base. Uses roof margin for Z avoidance and re-enabled that for alt hold and loiter and implements auto yaw for loiter. 